### PR TITLE
add beacon_ignore_filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ To ignore a buffer you can set list of regexes
 g:beacon_ignore_buffers = [\w*git*\w]
 ```
 
+### Ignoring filetypes
+To ignore filetypes you can set list of filetypes
+```viml
+g:beacon_ignore_filetypes = ['fzf']
+```
+
 ## Commands
 There is 4 commands available.
 - `:Beacon` highlight current position (even if plugin is disabled)

--- a/doc/beacon.txt
+++ b/doc/beacon.txt
@@ -37,6 +37,10 @@ OPTIONS                                         *beacon-option*
         List of regexes that will be tested against buffer name, and if
         matches beacon will not show up. Default [].
 
+    g:beacon_ignore_filetypes                   *g:beacon_ignore_filetypes*
+        List of filetypes that will be tested against &filetype, and if
+        matches beacon will not show up. Default [].
+
 CHANGE COLOR                                    *hl-Beacon*
 
 Beacon is highlighted by `Beacon` group, so you can change it like this:

--- a/plugin/beacon.vim
+++ b/plugin/beacon.vim
@@ -38,6 +38,7 @@ let g:beacon_show_jumps = get(g:, 'beacon_show_jumps', 1)
 let g:beacon_shrink = get(g:, 'beacon_shrink', 1)
 let g:beacon_timeout = get(g:, 'beacon_timeout', 500)
 let g:beacon_ignore_buffers = get(g:, 'beacon_ignore_buffers', [])
+let g:beacon_ignore_filetypes = get(g:, 'beacon_ignore_filetypes', [])
 
 " buffer needed for floating window
 if has("nvim")
@@ -47,6 +48,17 @@ let s:float = 0 " floating win id
 
 let s:fade_timer = 0
 let s:close_timer = 0
+
+fun! s:IsIgnoreFiletype()
+    let name = &filetype
+
+    for i in g:beacon_ignore_filetypes
+        if name =~ i
+            return 1
+        endif
+    endfor
+    return 0
+endf
 
 fun! s:IsIgnoreBuffer()
     let name = bufname()
@@ -141,6 +153,10 @@ function! s:Highlight_position(force) abort
     endif
 
     if s:IsIgnoreBuffer()
+        return
+    endif
+
+    if s:IsIgnoreFiletype()
         return
     endif
 


### PR DESCRIPTION
Beacon was messing with popup borders of fzf. Using the same syntax as you have, I've added ignore for filetypes, it appears to work and it no longer messes with the fzf popup borders.

Hopefully this PR is the right way to do it. Never done one before