### PR TITLE
set cursor_events to empty to disable highlighting jumps inside windows

### DIFF
--- a/lua/beacon.lua
+++ b/lua/beacon.lua
@@ -152,17 +152,19 @@ function M.setup(config)
     end,
   })
 
-  vim.api.nvim_create_autocmd(M.config.cursor_events, {
-    pattern = '*',
-    group = beacon_group,
-    desc = 'Highlight cursor moves',
-    ---@param event beacon.AutocmdEvent
-    callback = function(event)
-      vim.schedule(function()
-        cursor_moved(event)
-      end)
-    end,
-  })
+  if #M.config.cursor_events > 0 then
+    vim.api.nvim_create_autocmd(M.config.cursor_events, {
+      pattern = '*',
+      group = beacon_group,
+      desc = 'Highlight cursor moves',
+      ---@param event beacon.AutocmdEvent
+      callback = function(event)
+        vim.schedule(function()
+          cursor_moved(event)
+        end)
+      end,
+    })
+  end
 end
 
 return M


### PR DESCRIPTION
closes #32 

I think this may have been the original intention based on the wordings in `beacon.nvim` vimdoc. 

```
Disable highlighting jumps inside window
>lua
  require('beacon').setup({
    cursor_events = {} -- set empty
  })
<
```

I quickly tested it out with 

```
return {
    dev = true,
    dir = "~/Documents/nvim-plugins/beacon.nvim",
    opts = {
        enabled = true,
        speed = 2,
        width = 40,
        winblend = 70,
        fps = 60,
        min_jump = 20,
        cursor_events = {}, <---only thing that changed
        window_events = { "WinEnter", "FocusGained" },
        highlight = { bg = "white", ctermbg = 15 },
    },
}
``` 

- [ x]  jumping within a buffer = no highlight
- [ x] jumping across buffers = highlight as usual

