### PR TITLE
fix: use autocmd to set highlight group

### DIFF
--- a/lua/beacon.lua
+++ b/lua/beacon.lua
@@ -139,9 +139,14 @@ end
 function M.setup(config)
   M.config = vim.tbl_extend('force', default_config, config or {})
 
-  vim.api.nvim_set_hl(0, 'Beacon', M.config.highlight)
-
   local beacon_group = vim.api.nvim_create_augroup('beacon_group', { clear = true })
+
+  vim.api.nvim_create_autocmd('ColorScheme', {
+    group = beacon_group,
+    callback = function()
+      vim.api.nvim_set_hl(0, 'Beacon', M.config.highlight)
+    end,
+  })
 
   vim.api.nvim_create_autocmd(M.config.window_events, {
     pattern = '*',

--- a/lua/beacon.lua
+++ b/lua/beacon.lua
@@ -19,7 +19,7 @@ local default_config = {
   min_jump = 10,
   cursor_events = { 'CursorMoved' },
   window_events = { 'WinEnter', 'FocusGained' },
-  highlight = { bg = 'white', ctermbg = 15, default = true },
+  highlight = { bg = 'fg', ctermbg = 15, default = true },
 }
 
 -- weird behaviour in oil window


### PR DESCRIPTION
Avoid being cleared by colorscheme, since many colorscheme will run `hi clear`. Fix: #17 

Also, I think directly using bg color is a better default.